### PR TITLE
Explicitly specify MD mode to account for defaults between LibreSSL a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ export FOO=secret
 export BAR=alsosecret
 ```
 
-If they are encrypted with `openssl aes-256-cbc -e -in secret-env-plain -out secret-env-cipher -k $KEY`, and `$KEY` is set
+If they are encrypted with `openssl aes-256-cbc -e -md sha256 -in secret-env-plain -out secret-env-cipher -k $KEY`, and `$KEY` is set
 in the CircleCI project, the variables in `secret-env-plain` will be available in the build.
 
-You could use the same process but replace the `openssl` command in `circle.yml` with `openssl aes-256-cbc -d -in secret-file-cipher -out secret-file-plain -k $KEY` to create plaintext files in the build environment instead of just exporting environment variables.
+You could use the same process but replace the `openssl` command in `circle.yml` with `openssl aes-256-cbc -d -md sha256 -in secret-file-cipher -out secret-file-plain -k $KEY` to create plaintext files in the build environment instead of just exporting environment variables.


### PR DESCRIPTION
Having the following issue decrypting between the default openssl on Ubuntu that I encrypted with the default OpenSSL version bundled with MacOS 10.13: https://github.com/libressl-portable/portable/issues/378

Explicitly specifying the MD type fixes this.